### PR TITLE
修复重启后点击穿透导致窗口无法交互

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run linter
         run: pnpm lint
 
+      - name: 运行测试
+        run: pnpm test
+
       - name: Import Apple Certificate
         if: matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/v')
         # if: matrix.os == 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern, transparent chat overlay application for Bilibili live streaming built
 - **Transparent Overlay**: Seamlessly integrates with your streaming setup
 - **Always-on-Top Mode**: Keeps the overlay visible above other windows
 - **Click-Through Mode**: Interact with applications beneath the overlay
+  - 点击穿透仅在当前运行周期生效，重启后默认关闭，避免窗口因保存的点击穿透状态而无法交互
 - **Real-time Chat Display**: Shows messages, interactions, and special events
 - **Online User Count**: Displays current viewer count with smooth animations
 - **Persistent Settings**: Saves your preferences locally

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint --ext .ts,.tsx .",
+    "test": "node --test --experimental-strip-types tests/settings-persistence.test.mjs",
     "generate-icons": "ts-node scripts/generate-icons.ts"
   },
   "keywords": [],

--- a/src/store/settingsPersistence.ts
+++ b/src/store/settingsPersistence.ts
@@ -1,0 +1,21 @@
+type ClickThroughState = {
+  clickThrough: boolean
+}
+
+export function omitTransientSettings<T extends ClickThroughState>(state: T): Omit<T, 'clickThrough'> {
+  const { clickThrough, ...persistedState } = state
+  void clickThrough
+  return persistedState
+}
+
+export function mergePersistedSettings<T extends ClickThroughState>(persistedState: unknown, currentState: T): T {
+  const persisted =
+    persistedState && typeof persistedState === 'object' ? (persistedState as Partial<T>) : ({} as Partial<T>)
+
+  return {
+    ...currentState,
+    ...persisted,
+    // 点击穿透是窗口运行时状态，重启后必须从关闭状态开始。
+    clickThrough: false,
+  } as T
+}

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -1,11 +1,14 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+import { mergePersistedSettings, omitTransientSettings } from './settingsPersistence'
+
 interface SettingsState {
   // UI Settings
   opacity: number
   baseFontSize: number
   alwaysOnTop: boolean
+  // 窗口运行时状态：不随设置持久化，避免重启后锁死窗口。
   clickThrough: boolean
   showInteractionEvents: boolean
   showGiftFree: boolean
@@ -66,6 +69,8 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: 'overlay-settings', // unique name for localStorage key
+      partialize: state => omitTransientSettings(state),
+      merge: (persistedState, currentState) => mergePersistedSettings(persistedState, currentState),
     }
   )
 )

--- a/tests/settings-persistence.test.mjs
+++ b/tests/settings-persistence.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { mergePersistedSettings, omitTransientSettings } from '../src/store/settingsPersistence.ts'
+
+test('持久化设置时排除点击穿透状态', () => {
+  const persisted = omitTransientSettings({
+    clickThrough: true,
+    opacity: 80,
+    alwaysOnTop: false,
+  })
+
+  assert.deepEqual(persisted, { opacity: 80, alwaysOnTop: false })
+  assert.equal('clickThrough' in persisted, false)
+})
+
+test('读取旧设置时重置已保存的点击穿透状态', () => {
+  const merged = mergePersistedSettings(
+    { clickThrough: true, opacity: 90 },
+    { clickThrough: false, opacity: 80, alwaysOnTop: false }
+  )
+
+  assert.equal(merged.clickThrough, false)
+  assert.equal(merged.opacity, 90)
+  assert.equal(merged.alwaysOnTop, false)
+})
+
+test('无效持久化数据不会改变默认的运行时状态', () => {
+  const currentState = { clickThrough: false, opacity: 80 }
+
+  assert.deepEqual(mergePersistedSettings(null, currentState), currentState)
+})


### PR DESCRIPTION
## 变更摘要

- 将 `clickThrough` 从 Zustand 的持久化数据中排除，点击穿透仅在当前运行周期生效。
- 读取旧版本设置时强制恢复 `clickThrough: false`，已有问题配置无需删除配置目录即可恢复交互。
- 增加持久化边界测试、`pnpm test` 脚本和 CI 测试步骤，并补充 README 行为说明。

## 验证

- `pnpm test`：3 项测试全部通过。
- `pnpm lint`：0 个错误；仅有仓库原有的 2 个 warning。
- `pnpm make`：Electron Forge 开发构建通过。

Fixes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Click-through mode now applies only during the current run and is disabled after restarting.
  * Settings persistence now safely handles invalid or legacy saved data.

* **Bug Fixes**
  * Prevented transient click-through settings from being restored unintentionally after restart.

* **Tests**
  * Added automated coverage for settings persistence, reset behavior, and invalid saved data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->